### PR TITLE
Tacs-51 auth bearer token authorization

### DIFF
--- a/auth/src/auth/app/dependencies.py
+++ b/auth/src/auth/app/dependencies.py
@@ -16,6 +16,8 @@ from auth.service_layer.password_encoder import BcryptPasswordEncoder, PasswordE
 from auth.service_layer.register import RegisterService
 
 mongo_settings = MongoDbSettings()
+user_repository: UserRepository | None = None
+password_encoder: PasswordEncoder | None = None
 
 
 def get_client_factory() -> ClientFactory:
@@ -42,7 +44,12 @@ def get_user_repository(db: DatabaseDependency) -> UserRepository:
     """
     Dependency that returns a UserRepository instance.
     """
-    return PymongoUserRepository(database=db)
+    global user_repository
+
+    if user_repository is None:
+        user_repository = PymongoUserRepository(database=db)
+
+    return user_repository
 
 
 UserRepositoryDependency = Annotated[UserRepository, Depends(get_user_repository)]
@@ -52,19 +59,24 @@ def get_password_encoder() -> PasswordEncoder:
     """
     Dependency that returns a PasswordEncoder instance.
     """
-    return BcryptPasswordEncoder()
+    global password_encoder
+
+    if password_encoder is None:
+        password_encoder = BcryptPasswordEncoder()
+
+    return password_encoder
 
 
 PasswordEncoderDependency = Annotated[PasswordEncoder, Depends(get_password_encoder)]
 
 
-def get_register_service(user_repository: UserRepositoryDependency,
+def get_register_service(user_repo: UserRepositoryDependency,
                          encoder: PasswordEncoderDependency) -> RegisterService:
     """
     Dependency that returns a RegisterService instance.
     """
     return RegisterService(
-        user_repository=user_repository,
+        user_repository=user_repo,
         password_encoder=encoder,
     )
 
@@ -82,14 +94,14 @@ def get_jwt_service() -> JwtService:
 JwtServiceDependency = Annotated[JwtService, Depends(get_jwt_service)]
 
 
-def get_auth_service(user_repository: UserRepositoryDependency,
+def get_auth_service(user_repo: UserRepositoryDependency,
                      jwt_service: JwtServiceDependency,
                      encoder: PasswordEncoderDependency) -> AuthService:
     """
     Dependency that returns a RegisterService instance.
     """
     return AuthService(
-        user_repository=user_repository,
+        user_repository=user_repo,
         encoder=encoder,
         jwt_service=jwt_service,
     )

--- a/auth/src/auth/app/dependencies.py
+++ b/auth/src/auth/app/dependencies.py
@@ -4,6 +4,7 @@ FastAPI dependencies are reusable components that can be used across multiple ro
 from typing import Annotated
 
 from fastapi import Depends
+from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
 from pymongo.database import Database
 
 from auth.adapters.db import ClientFactory
@@ -18,6 +19,9 @@ from auth.service_layer.register import RegisterService
 mongo_settings = MongoDbSettings()
 user_repository: UserRepository | None = None
 password_encoder: PasswordEncoder | None = None
+bearer_auth = HTTPBearer(scheme_name='JSON Web Token', description='Bearer JWT')
+
+BearerTokenAuth = Annotated[HTTPAuthorizationCredentials, Depends(bearer_auth)]
 
 
 def get_client_factory() -> ClientFactory:

--- a/auth/src/auth/entrypoints/v1/auth.py
+++ b/auth/src/auth/entrypoints/v1/auth.py
@@ -1,11 +1,12 @@
 """Authentication & Authorization Entry Points
 
 """
+
 from fastapi import APIRouter, HTTPException
 from starlette.status import HTTP_200_OK, HTTP_401_UNAUTHORIZED
 
-from auth.app.dependencies import AuthDependency
-from auth.domain.commands import AuthenticateUser, AuthorizeToken
+from auth.app.dependencies import AuthDependency, BearerTokenAuth
+from auth.domain.commands import AuthenticateUser
 from auth.domain.events import TokenGenerated, UserAuthenticated
 from auth.domain.schemas import ResponseModel
 from auth.service_layer.errors import InvalidCredentialsError
@@ -26,15 +27,16 @@ async def log_in(command: AuthenticateUser, auth_service: AuthDependency) -> Res
     return ResponseModel(data=TokenGenerated(token=token))
 
 
-@router.post('/user', status_code=HTTP_200_OK, tags=["Commands"])
-async def authorize_token(
-        command: AuthorizeToken,
-        auth_service: AuthDependency) -> ResponseModel[UserAuthenticated]:
+@router.get('/me', status_code=HTTP_200_OK, tags=["Commands"])
+async def me(
+        token: BearerTokenAuth,
+        auth_service: AuthDependency,
+) -> ResponseModel[UserAuthenticated]:
     """
     Authorizes a token, providing the user's information.
     """
     try:
-        user = auth_service.authorize(command.token)
+        user = auth_service.authorize(token.credentials)
     except InvalidCredentialsError as e:
         raise HTTPException(status_code=HTTP_401_UNAUTHORIZED, detail=str(e))
 

--- a/auth/src/auth/version.py
+++ b/auth/src/auth/version.py
@@ -1,4 +1,4 @@
 """
 Application Version
 """
-__version__ = "0.2.0"
+__version__ = "0.3.0"

--- a/auth/tests/e2e/entrypoints/v1/test_auth.py
+++ b/auth/tests/e2e/entrypoints/v1/test_auth.py
@@ -75,7 +75,9 @@ class TestAuthEntryPoint:
 
         with DependencyOverrider(overrides=overrides):
             # when
-            response = test_client.post('/api/v1/auth/user', json=authorize_command.dict())
+            response = test_client.get('/api/v1/auth/me',
+                                       headers={'Authorization': f'Bearer {authorize_command.token}'}
+                                       )
 
             username = response.json()['data']['username']
 
@@ -93,7 +95,9 @@ class TestAuthEntryPoint:
 
         with DependencyOverrider(overrides=overrides):
             # when
-            response = test_client.post('/api/v1/auth/user', json=authorize_command.dict())
+            response = test_client.get('/api/v1/auth/me',
+                                       headers={'Authorization': f'Bearer {authorize_command.token}'}
+                                       )
 
             # then
             assert response.status_code == HTTP_401_UNAUTHORIZED
@@ -109,7 +113,9 @@ class TestAuthEntryPoint:
 
         with DependencyOverrider(overrides=overrides):
             # when
-            response = test_client.post('/api/v1/auth/user', json=authorize_command.dict())
+            response = test_client.get('/api/v1/auth/me',
+                                       headers={'Authorization': f'Bearer {authorize_command.token}'}
+                                       )
 
             # then
             assert response.status_code == HTTP_401_UNAUTHORIZED


### PR DESCRIPTION
## What's changed?

## Auth v0.3.0

* Add Header Authentication
* Allows Swagger Authentication
* Changes authorization
  * Changes path to `'api/v1/auth/me'` 
  * Changes method to `GET`
  * Adds mandatory `Authentication: Bearer <TOKEN>` header