### PR TITLE
Tacs 52 gateway bearer token proxy

### DIFF
--- a/api-gateway/app/adapters/network.py
+++ b/api-gateway/app/adapters/network.py
@@ -98,6 +98,7 @@ async def gateway(
         path: str,
         query_params: dict | None = None,
         request_body: dict | str | None = None,
+        headers: dict | None = None,
 ) -> tuple[dict[str, Any], int]:
     """
     Make request to in-network services.
@@ -109,6 +110,7 @@ async def gateway(
         path: is the path to bind (like app.post('/api/users/'))
         query_params: is the query params to add to url
         request_body: is the payload
+        headers: request headers
 
     Returns:
         service result coming / non-blocking http request (coroutine)
@@ -125,7 +127,8 @@ async def gateway(
 
     url = f'{service_url}{path}' if not query_params else f'{service_url}{path}?{urlencode(query_params)}'
 
-    headers = dict()
+    if not headers:
+        headers = dict()
 
     response: aiohttp.ClientResponse
 

--- a/api-gateway/app/dependencies.py
+++ b/api-gateway/app/dependencies.py
@@ -4,6 +4,7 @@ FastAPI dependencies injection.
 from typing import Annotated
 
 from fastapi import Depends
+from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
 
 from app.adapters.http_client import AsyncHttpClient, aio_http_client
 from app.adapters.redis_connector import RedisClient, RedisClusterConnection, RedisConnector
@@ -14,6 +15,9 @@ from app.settings.gateway_settings import GatewaySettings
 from app.settings.redis_config import RedisSettings
 
 redis_connector: RedisConnector | None = None
+bearer_auth = HTTPBearer(scheme_name='JSON Web Token', description='Bearer JWT')
+
+BearerTokenAuth = Annotated[HTTPAuthorizationCredentials, Depends(bearer_auth)]
 
 
 def get_async_http_client() -> AsyncHttpClient:

--- a/api-gateway/app/domain/commands/scheduler_service.py
+++ b/api-gateway/app/domain/commands/scheduler_service.py
@@ -22,23 +22,34 @@ class ScheduleMeeting(CamelCaseModel):
     """
     Command to schedule a meeting.
     """
-
-    organizer: str = Field(description="Responsible for the meeting's username.", example="johndoe")
     title: str | None = Field(description="The meeting's title.", example="Coffee with John Doe")
     description: str | None = Field(description="The meeting's description.",
                                     example="A meeting to discuss the project.")
     location: str | None = Field(description="The meeting's location.", example="Floor 3, Cafeteria")
     options: list[ProposeOption] = Field(description="A list of options to schedule the meeting.", min_items=1)
+
+
+class ForwardScheduleMeeting(ScheduleMeeting):
+    """
+    Forwarded Command.
+    """
+    organizer: str = Field(description="Responsible for the meeting's username.", example="johndoe")
     guests: set[str] = Field(description="A list of guests to invite to the meeting.",
-                             example=["frank", "jane"], default_factory=set)
+                             example=[], default_factory=set, max_items=0)
 
 
 class ToggleVoting(CamelCaseModel):
     """
     Command to toggle voting on a meeting.
     """
-    username: str = Field(description="Responsible for the meeting's username.", example="johndoe")
     voting: bool = Field(description="Whether voting is enabled", example=True, default=True)
+
+
+class ForwardToggleVoting(ToggleVoting):
+    """
+    Forwarded Command.
+    """
+    username: str = Field(description="Responsible for the meeting's username.", example="johndoe")
 
 
 class JoinMeeting(CamelCaseModel):
@@ -49,6 +60,13 @@ class JoinMeeting(CamelCaseModel):
 
 
 class VoteOption(CamelCaseModel):
+    """
+    Command to vote on a meeting option.
+    """
+    option: ProposeOption = Field(description="The option to vote on.")
+
+
+class ForwardVoteOption(VoteOption):
     """
     Command to vote on a meeting option.
     """

--- a/api-gateway/app/entrypoints/v1/auth_service.py
+++ b/api-gateway/app/entrypoints/v1/auth_service.py
@@ -9,8 +9,9 @@ from starlette.status import HTTP_200_OK, HTTP_201_CREATED
 from app.adapters.network import gateway
 from app.dependencies import AsyncHttpClientDependency, ServiceProvider
 from app.domain.commands.auth_service import AuthenticateUser, RegisterUser
-from app.domain.events.auth_service import TokenGenerated, UserRegistered
+from app.domain.events.auth_service import TokenGenerated, UserAuthenticated, UserRegistered
 from app.domain.schemas import ResponseModel, ResponseModels
+from app.middleware import AuthMiddleware
 from app.service_layer.gateway import api_v1_url, get_service, get_users, verify_status
 
 router = APIRouter(prefix="/auth-service", tags=["Auth"])
@@ -118,3 +119,18 @@ async def authenticate(command: AuthenticateUser,
     verify_status(response=auth_response, status_code=status_code)
 
     return ResponseModel[TokenGenerated](**auth_response)
+
+
+@router.get("/auth/me",
+            status_code=HTTP_200_OK,
+            summary="Authenticates current user",
+            tags=["Queries"],
+            )
+async def authenticate_me(
+        user: AuthMiddleware
+) -> ResponseModel[UserAuthenticated]:
+    """
+    Validates a user token. If valid, retrieves the user information.
+    """
+
+    return ResponseModel[UserAuthenticated](data=user)

--- a/api-gateway/app/middleware.py
+++ b/api-gateway/app/middleware.py
@@ -1,10 +1,15 @@
 """
 FastAPI middlewares
 """
-from fastapi import HTTPException, Request
+from typing import Annotated
+
+from fastapi import Depends, HTTPException, Request
 from starlette import status
 
-from app.dependencies import RateLimiterDependency
+from app.adapters.network import gateway
+from app.dependencies import AsyncHttpClientDependency, BearerTokenAuth, RateLimiterDependency, ServiceProvider
+from app.domain.events.auth_service import UserAuthenticated
+from app.service_layer.gateway import api_v1_url, get_service, verify_status
 
 
 async def rate_limiter_middleware(request: Request, rate_limiter: RateLimiterDependency):
@@ -27,3 +32,36 @@ async def rate_limiter_middleware(request: Request, rate_limiter: RateLimiterDep
         raise HTTPException(status_code=status.HTTP_429_TOO_MANY_REQUESTS, detail=f"Surpassed rate limit.")
 
     await rate_limiter.timer(key, time=rate_limiter.time_to_live)
+
+
+async def auth_middleware(token: BearerTokenAuth,
+                          services: ServiceProvider,
+                          client: AsyncHttpClientDependency) -> UserAuthenticated:
+    """
+    Authentication middleware.
+
+    Args:
+        token: Authorization credentials
+        services: available service
+        client: HTTP client
+
+    Returns:
+        UserAuthenticated: User information
+
+    Raises:
+        HTTPException: if the token is invalid
+    """
+    auth_response, status_code = await gateway(
+        service_url=(await get_service(service_name="auth", services=services)).base_url,
+        path=f"{api_v1_url}/auth/me",
+        client=client,
+        method="GET",
+        headers={"Authorization": f"Bearer {token.credentials}"}
+    )
+
+    verify_status(response=auth_response, status_code=status_code)
+
+    return UserAuthenticated(**auth_response.get("data"))
+
+
+AuthMiddleware = Annotated[UserAuthenticated, Depends(auth_middleware)]

--- a/api-gateway/app/version.py
+++ b/api-gateway/app/version.py
@@ -1,4 +1,4 @@
 """
 Application Version
 """
-__version__ = "0.4.0"
+__version__ = "0.5.0"

--- a/api-gateway/tests/conftest.py
+++ b/api-gateway/tests/conftest.py
@@ -75,3 +75,11 @@ async def fixture_redis_client() -> RedisClient:
     client = RedisClient(url="fake-host", port=6379)
     yield client
     await client.close()
+
+
+@pytest.fixture(name="auth_headers")
+def fixture_headers() -> dict[str, str]:
+    """
+    Create a dict with headers.
+    """
+    return {"Authorization": "Bearer eyThisIsAFakeToken"}

--- a/api-gateway/tests/integration/service_layer/test_gateway.py
+++ b/api-gateway/tests/integration/service_layer/test_gateway.py
@@ -1,18 +1,16 @@
 """
 Test for the gateway service layer
 """
-import json
 from typing import Any
 
+import pytest
 from aioresponses import aioresponses
 from fastapi import HTTPException
-import pytest
 from starlette.status import HTTP_200_OK, HTTP_201_CREATED, HTTP_202_ACCEPTED, HTTP_404_NOT_FOUND, \
     HTTP_503_SERVICE_UNAVAILABLE
 
 from app.domain.models import Service
-from app.service_layer.gateway import get_users, verify_scheduling_meeting, verify_status
-from tests.mocks import schedule_command_factory, user_registered_factory
+from app.service_layer.gateway import get_users, verify_status
 
 
 class TestGateway:
@@ -72,107 +70,3 @@ class TestGateway:
         # when / then
         with pytest.raises(HTTPException):
             await verify_status(response=payload, status_codes=valid_values, status_code=response_status)
-
-    @pytest.mark.asyncio
-    async def test_schedule_command_is_ok(self, fake_web, auth_service, aio_http_client):
-        """
-        GIVEN a schedule command with a valid organizer
-        WHEN verification is made
-        THEN it should return the same command.
-        """
-        # given
-        organizer = "johndoe"
-        command = schedule_command_factory(organizer=organizer)
-        json_dict = json.loads(user_registered_factory(username=organizer).json(by_alias=True))
-        payload = {"data": [json_dict]}
-        fake_web.get(f"{auth_service.base_url}/api/v1/users?usernames=johndoe", payload=payload, status=HTTP_200_OK)
-
-        # when
-        updated_command = await verify_scheduling_meeting(command=command, service=auth_service, client=aio_http_client)
-
-        # then
-        assert command == updated_command
-
-    @pytest.mark.asyncio
-    async def test_schedule_command_is_ok_with_guests(self, fake_web, auth_service, aio_http_client):
-        """
-        GIVEN a schedule command with a valid organizer and guests
-        WHEN verification is made
-        THEN it should return the same command.
-        """
-        # given
-        organizer = "johndoe"
-        guest_1 = "janedoe"
-        guest_2 = "mark"
-        guests = {guest_1, guest_2}
-
-        command = schedule_command_factory(organizer=organizer, guests=guests)
-        users = guests.copy()
-        users.add(organizer)
-        query = f"usernames={', '.join(users)}"
-
-        json_dict = json.loads(user_registered_factory(username=organizer).json(by_alias=True))
-        json_dict_2 = json.loads(user_registered_factory(username=guest_1).json(by_alias=True))
-        json_dict_3 = json.loads(user_registered_factory(username=guest_2).json(by_alias=True))
-        payload = {"data": [json_dict, json_dict_2, json_dict_3]}
-
-        fake_web.get(f"{auth_service.base_url}/api/v1/users?{query}", payload=payload, status=HTTP_200_OK)
-
-        # when
-        updated_command = await verify_scheduling_meeting(command=command, service=auth_service, client=aio_http_client)
-
-        # then
-        assert command == updated_command
-
-    @pytest.mark.asyncio
-    async def test_schedule_command_with_missing_guests(self, fake_web, auth_service, aio_http_client):
-        """
-        GIVEN a schedule command with a valid organizer but invalid guests
-        WHEN verification is made
-        THEN only valid guests should be returned.
-        """
-        # given
-        organizer = "johndoe"
-        guest_1 = "janedoe"
-        guest_2 = "mark"
-        guests = {guest_1, guest_2}
-
-        command = schedule_command_factory(organizer=organizer, guests=guests)
-        users = guests.copy()
-        users.add(organizer)
-        query = f"usernames={', '.join(users)}"
-
-        json_dict = json.loads(user_registered_factory(username=organizer).json(by_alias=True))
-        json_dict_2 = json.loads(user_registered_factory(username=guest_1).json(by_alias=True))
-        payload = {"data": [json_dict, json_dict_2]}
-
-        fake_web.get(f"{auth_service.base_url}/api/v1/users?{query}", payload=payload, status=HTTP_200_OK)
-
-        # when
-        updated_command = await verify_scheduling_meeting(command=command, service=auth_service, client=aio_http_client)
-
-        # then
-        assert command != updated_command
-        assert guest_2 not in updated_command.guests
-
-    @pytest.mark.asyncio
-    async def test_schedule_command_with_missing_organizer(self, fake_web, auth_service, aio_http_client):
-        """
-        GIVEN a schedule command an invalid organizer
-        WHEN verification is made
-        THEN should raise an exception.
-        """
-        # given
-        organizer = "johndoe"
-
-        command = schedule_command_factory(organizer=organizer)
-
-        fake_web.get(f"{auth_service.base_url}/api/v1/users?usernames={organizer}",
-                     payload={"data": []},
-                     status=HTTP_200_OK)
-
-        # when
-        with pytest.raises(HTTPException):
-            updated_command = await verify_scheduling_meeting(command=command,
-                                                              service=auth_service,
-                                                              client=aio_http_client)

--- a/api-gateway/tests/mocks.py
+++ b/api-gateway/tests/mocks.py
@@ -44,21 +44,18 @@ def user_registered_response_factory(username: str, user_id: str | None = None) 
     }
 
 
-def schedule_command_factory(organizer: str,
-                             title: str = "Test Meeting", guests: set[str] | None = None) -> ScheduleMeeting:
+def schedule_command_factory(title: str = "Test Meeting") -> ScheduleMeeting:
     """
     Creates a schedule command.
 
     Args:
-        organizer (str): The organizer.
         title (str, optional): The title. Defaults to "Test Meeting".
-        guests (set[str], optional): The guests. Defaults to None.
 
     Returns:
         dict[str, Any]: The schedule command.
     """
     fake_options = [ProposeOption(date=datetime.date.today(), hour=12, minute=30)]
-    return ScheduleMeeting(organizer=organizer, title=title, guests=guests or set(), options=fake_options)
+    return ScheduleMeeting(title=title, options=fake_options)
 
 
 class FakeRedis(RedisConnector):

--- a/scheduler/src/main/java/com/schedutn/scheduler/SchedulerApplication.java
+++ b/scheduler/src/main/java/com/schedutn/scheduler/SchedulerApplication.java
@@ -7,7 +7,7 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 @OpenAPIDefinition(
         info = @io.swagger.v3.oas.annotations.info.Info(
                 title = "Scheduler Service",
-                version = "0.1.1",
+                version = "0.1.2",
                 description = "Scheduler manages the workflow of meetings scheduling",
                 license = @io.swagger.v3.oas.annotations.info.License(
                         name = "MIT",

--- a/scheduler/src/main/java/com/schedutn/scheduler/domain/commands/ScheduleMeeting.kt
+++ b/scheduler/src/main/java/com/schedutn/scheduler/domain/commands/ScheduleMeeting.kt
@@ -43,7 +43,7 @@ data class ScheduleMeeting(
   @field:Valid
   val options: Set<ProposeOption>,
 
-  @Schema(description = "Meeting Guests invited", example = "[]")
+  @Schema(description = "Meeting Guests invited", example = "[]", deprecated = true)
   @JsonProperty("guests")
   val guests: Set<String>? = emptySet(),
 ) : Command


### PR DESCRIPTION
## What's Changed

### Scheduler v0.1.2

#### Fixes

* Deprecated `guests` property from `Schedule` command.

### API Gateway v0.5.0

#### Features

* Authorization with JWT
* Replaced command properties with header information.
* Add `/me` path